### PR TITLE
[修正]スキル発動回数ランキング、および発動者別で表示を選んだ時のヒット件数、ページネートが正しく集計されなかった不具合

### DIFF
--- a/app/models/battle_action.rb
+++ b/app/models/battle_action.rb
@@ -29,7 +29,8 @@ class BattleAction < ApplicationRecord
         group_page(params).
         group_turn(params).
         group_acter(params).
-        group("battle_actions.skill_id, battle_actions.fuka_id")
+        group_skill(params).
+        group_fuka(params)
     }
   
     scope :group_page, ->(params) {
@@ -45,8 +46,35 @@ class BattleAction < ApplicationRecord
     }
 
     scope :group_acter, ->(params) {
+        group_e_no(params).
+        group_enemy(params)
+    }
+  
+    scope :group_e_no, ->(params) {
         if params["group_acter"] == "on" then
-            group("battle_acters.e_no, battle_acters.enemy_id")
+            if params["acter_pc"] == "on" ||  params[:q]["acter_acter_type_eq_any"].size == 0 then
+                group("battle_acters.e_no")
+            end
+        end
+    }
+ 
+    scope :group_enemy, ->(params) {
+        if params["group_acter"] == "on" then
+            if params["acter_npc"] == "on" ||  params[:q]["acter_acter_type_eq_any"].size == 0 then
+                group("battle_acters.enemy_id")
+            end
+        end
+    }
+
+    scope :group_skill, ->(params) {
+        if params["act_type_skill"] == "on" || params["act_type_normal"] == "on" || params[:q]["act_type_eq_any"].size == 0 then
+            group("battle_actions.skill_id")
+        end
+    }
+
+    scope :group_fuka, ->(params) {
+        if params["act_type_fuka"] == "on" || !params[:q]["act_type_eq_any"]  || params[:q]["act_type_eq_any"].size == 0 then
+            group("battle_actions.fuka_id")
         end
     }
 

--- a/app/views/battle_actions/index.html.haml
+++ b/app/views/battle_actions/index.html.haml
@@ -81,8 +81,8 @@
 
     - #==========================================================================================================================
     - tbody_toggle(@form_params, params_name: "show_group",
-                    label: {open: "特定の要素で結果をまとめる", close: "特定の要素で結果をまとめる選択肢を隠す"},
-                    act_desc: "ターン別、結果別", base_first: false)
+                    label: {open: "特定の要素で結果を詳細化する", close: "結果を詳細化する選択肢を隠す"},
+                    act_desc: "ターン別、結果別、発動者別", base_first: false)
     %tbody.closed
       %tr
         %td.indent
@@ -115,7 +115,6 @@
         %td{colspan: "3"}
           - search_submit_button
 
-
 = paginate(@battle_actions)
 %br
 ヒット数：#{ @count }件
@@ -135,13 +134,12 @@
         %th= sort_link(@search, :turn, "ターン", default_order: :desc)
       %th= sort_link(@search, :skill_id, "スキル", default_order: :desc)
       %th= sort_link(@search, :fuka_id, "付加", default_order: :desc)
-      - if @form_params["group_page"] != "on" || @form_params["group_turn"] != "on"
-        -if @form_params["total_act"] == "on"
-          %th= sort_link(@search, :act_count, "発動回数", default_order: :desc)
-        -if @form_params["total_acter"] == "on"
-          %th= sort_link(@search, :acter_count, "発動者数", default_order: :desc)
-        -if @form_params["total_page"] == "on"
-          %th= sort_link(@search, :page_count, "発動結果数", default_order: :desc)
+      -if @form_params["total_act"] == "on"
+        %th= sort_link(@search, :act_count, "発動回数", default_order: :desc)
+      -if @form_params["total_acter"] == "on"
+        %th= sort_link(@search, :acter_count, "発動者数", default_order: :desc)
+      -if @form_params["total_page"] == "on"
+        %th= sort_link(@search, :page_count, "発動結果数", default_order: :desc)
       - if @form_params["group_page"] == "on"
         %th= sort_link(@search, :battle_info_battle_page, "結果名", default_order: :desc)
       %th.sep{colspan: "2"} 結果リンク
@@ -167,13 +165,12 @@
           %td{colspan: 2}= battle_action.skill.name if battle_action.skill
         - elsif battle_action.act_type == 2
           %td{colspan: 2}= battle_action.fuka.name if battle_action.fuka
-        - if @form_params["group_page"] != "on" || @form_params["group_turn"] != "on"
-          -if @form_params["total_act"] == "on"
-            %td= battle_action.act_count
-          -if @form_params["total_acter"] == "on"
-            %td= battle_action.acter_count
-          -if @form_params["total_page"] == "on"
-            %td= battle_action.page_count
+        -if @form_params["total_act"] == "on"
+          %td= battle_action.act_count
+        -if @form_params["total_acter"] == "on"
+          %td= battle_action.acter_count
+        -if @form_params["total_page"] == "on"
+          %td= battle_action.page_count
         - if @form_params["group_page"] == "on"
           %td= battle_action.battle_info.battle_page if battle_action.battle_info
         - if @form_params["group_page"] == "on" && battle_action.battle_info


### PR DESCRIPTION
・他の修正のためにいじっていたら偶然にも。groupする要素ごとにgroup関数を呼び出すと正しく集計される？