### PR TITLE
[修正]hamlでのDOCTYPEの記述をマニュアル通りに

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,4 @@
-!!! s
+!!!
 %html
   %head
     %meta{charset: "utf-8"}


### PR DESCRIPTION
・出力される内容は変わらない